### PR TITLE
Bump actions/setup-python from 5.0.0 to 5.1.0

### DIFF
--- a/.github/workflows/env_fixed.yml
+++ b/.github/workflows/env_fixed.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.1.0
         with:
             python-version: '3.11'
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.1.0
         with:
             python-version: ${{ matrix.python-version }}
 
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.1.0
         with:
             python-version: ${{ matrix.python-version }}
 
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.1.0
         with:
             python-version: '3.10'
 


### PR DESCRIPTION
### Description

In this pull request, the version of the `actions/setup-python` action is being updated from `v5.0.0` to `v5.1.0` in several places within the GitHub Actions workflow files.

- Updated the version of `actions/setup-python` action from `v5.0.0` to `v5.1.0` in multiple locations within the workflow files.

These changes ensure that the Python setup action uses the latest version `v5.1.0`, providing potential improvements or bug fixes introduced in the new version.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Bump the `actions/setup-python` GitHub Action from version 5.0.0 to 5.1.0 in the workflow configuration files.

### Why are these changes being made?

This update ensures that the workflows use the latest features and bug fixes provided in version 5.1.0 of the `actions/setup-python` action, which may include improvements in performance, security, or compatibility with newer Python versions. Keeping dependencies up-to-date is a best practice to maintain the reliability and efficiency of the CI/CD pipeline.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->